### PR TITLE
Restore disaggregation by groups

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: daedalus.compare
 Title: Run Multiple Scenarios of the Daedalus Model
-Version: 0.0.2
+Version: 0.0.3
 Authors@R: c(
     person("Pratik", "Gupte", , "pratik.gupte@lshtm.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5294-7819")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# daedalus.compare 0.0.3
+
+Restores ability to get epidemic summary disaggregated by age and other groups by passing arguments to `daedalus::get_epidemic_summary()` via `...` in `get_summary_data()`.
+
 # daedalus.compare 0.0.2
 
 Updates for compatibility with _daedalus_ >= v0.2.16 which re-introduces list-infection inputs.

--- a/R/scenario_helpers.R
+++ b/R/scenario_helpers.R
@@ -47,16 +47,18 @@ get_costs_list <- function(l, names) {
 #'
 #' @inheritParams get_costs_list
 #'
+#' @param ... Additional arguments passed to [daedalus::get_epidemic_summary()].
+#'
 #' @return A `<data.table>`.
 #'
 #' @keywords internal
-get_summary_list <- function(l, names = c("lower", "mean", "upper")) {
+get_summary_list <- function(l, names, ...) {
   # no input checks on internal functions
   summary_dt <- Map(
     l,
     names,
     f = function(x, n) {
-      df <- daedalus::get_epidemic_summary(x)
+      df <- daedalus::get_epidemic_summary(x, ...)
       df$tag <- n
 
       df
@@ -213,12 +215,20 @@ run_scenarios <- function(
 #' is a small number of `disease_tags`, typically a triplet of "low", "medium",
 #' and "high" risk scenarios.
 #'
+#' @param ... Additional arguments passed to [daedalus::get_epidemic_summary()].
+#' If passing `groups`, only `format = "long"` is supported.
+#'
 #' @return A `<data.frame>` summarising epidemiological outcomes: cumulative
 #' infections, deaths, and hospitalisations over the timeframe of the modelled
 #' epidemics.
 #'
 #' @export
-get_summary_data <- function(dt, disease_tags, format = c("long", "wide")) {
+get_summary_data <- function(
+  dt,
+  disease_tags,
+  format = c("long", "wide"),
+  ...
+) {
   # input checks
   checkmate::assert_data_table(dt, any.missing = FALSE)
   checkmate::assert_character(disease_tags)
@@ -227,7 +237,8 @@ get_summary_data <- function(dt, disease_tags, format = c("long", "wide")) {
   dt$epi_summary <- lapply(
     dt$output,
     get_summary_list,
-    disease_tags
+    disease_tags,
+    ...
   )
 
   format <- rlang::arg_match(format)

--- a/man/get_summary_data.Rd
+++ b/man/get_summary_data.Rd
@@ -4,7 +4,7 @@
 \alias{get_summary_data}
 \title{Get summary data from DAEDALUS scenarios}
 \usage{
-get_summary_data(dt, disease_tags, format = c("long", "wide"))
+get_summary_data(dt, disease_tags, format = c("long", "wide"), ...)
 }
 \arguments{
 \item{dt}{A \verb{<data.table>} resulting from \code{run_scenarios()}.}
@@ -16,6 +16,9 @@ each scenario.}
 \code{"wide"} format. Returning a 'wide' data.frame is only recommended when there
 is a small number of \code{disease_tags}, typically a triplet of "low", "medium",
 and "high" risk scenarios.}
+
+\item{...}{Additional arguments passed to \code{\link[daedalus:epi_output_helpers]{daedalus::get_epidemic_summary()}}.
+If passing \code{groups}, only \code{format = "long"} is supported.}
 }
 \value{
 A \verb{<data.frame>} summarising epidemiological outcomes: cumulative

--- a/man/get_summary_list.Rd
+++ b/man/get_summary_list.Rd
@@ -4,13 +4,15 @@
 \alias{get_summary_list}
 \title{Get epidemic summary data from a list of model outputs}
 \usage{
-get_summary_list(l, names = c("lower", "mean", "upper"))
+get_summary_list(l, names, ...)
 }
 \arguments{
 \item{l}{A list of \verb{<daedalus_output>} objects; each object will be passed to
 \code{daedalus::get_costs()}.}
 
 \item{names}{A character vector, intended to apply to elements of \code{l}.}
+
+\item{...}{Additional arguments passed to \code{\link[daedalus:epi_output_helpers]{daedalus::get_epidemic_summary()}}.}
 }
 \value{
 A \verb{<data.table>}.

--- a/tests/testthat/test-scenario-helpers.R
+++ b/tests/testthat/test-scenario-helpers.R
@@ -190,6 +190,44 @@ test_that("Get epi summary data", {
       groups = "age_group"
     ),
   )
+
+  group_wanted <- "age_group"
+  measures_expected <- c("total_deaths", "epidemic_size") # different from args
+  summary_data <- get_summary_data(
+    output,
+    disease_tags,
+    "long",
+    measures = c("deaths", "infections"),
+    groups = group_wanted
+  )
+  expect_true(
+    group_wanted %in% colnames(summary_data)
+  )
+  expect_true(
+    all(measures_expected %in% summary_data$measure)
+  )
+
+  expect_error(
+    get_summary_data(
+      output,
+      disease_tags,
+      "long",
+      measures = c("deaths", "infections"),
+      groups = "dummy_group"
+    ),
+    "Expected `groups` to be either `NULL` or a character vector"
+  )
+
+  expect_error(
+    get_summary_data(
+      output,
+      disease_tags,
+      "long",
+      measures = "dummy_measure",
+      groups = "age_group"
+    ),
+    "`measures` must be one of"
+  )
 })
 
 test_that("Get costs data", {

--- a/tests/testthat/test-scenario-helpers.R
+++ b/tests/testthat/test-scenario-helpers.R
@@ -176,6 +176,20 @@ test_that("Get epi summary data", {
   expect_no_condition(
     get_summary_data(output, disease_tags, "wide")
   )
+
+  expect_no_condition(
+    get_summary_data(output, disease_tags, "wide", measures = "deaths"),
+  )
+
+  expect_no_condition(
+    get_summary_data(
+      output,
+      disease_tags,
+      "long",
+      measures = c("deaths", "infections"),
+      groups = "age_group"
+    ),
+  )
 })
 
 test_that("Get costs data", {


### PR DESCRIPTION
This PR restores disaggregation by groups in `get_data_summary()` by allowing users to pass options to `daedalus::get_epidemic_summary()` via `...`.