### PR TITLE
Daedalus v0.2.38 compat

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: daedalus.compare
 Title: Run Multiple Scenarios of the Daedalus Model
-Version: 0.0.5
+Version: 0.0.6
 Authors@R: c(
     person("Pratik", "Gupte", , "pratik.gupte@lshtm.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5294-7819")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# daedalus.compare 0.0.6
+
 # daedalus.compare 0.0.5
 
 This patch version allows users to run multiple vaccination scenarios by passing a list of `<daedalus_vaccination>` objects to `run_scenarios()`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # daedalus.compare 0.0.6
 
-This patch version updates _daedalus.compare_ to be compatible with _daedalus_ >= v0.2.38 as introduced in [daedalus PR 109](https://github.com/jameel-institute/daedalus/pull/109).
+This patch version updates _daedalus.compare_ to be compatible with _daedalus_ >= v0.2.38 which introduced separate hospitalisation compartments in [daedalus PR 109](https://github.com/jameel-institute/daedalus/pull/109). This should have been fixed in v0.0.4.
 
 - The function `get_epidata_list()` now accesses compartments "hospitalised_recov" and "hospitalised_death" to calculate total hospital demand.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # daedalus.compare 0.0.6
 
+This patch version updates _daedalus.compare_ to be compatible with _daedalus_ >= v0.2.38 as introduced in [daedalus PR 109](https://github.com/jameel-institute/daedalus/pull/109).
+
+- The function `get_epidata_list()` now accesses compartments "hospitalised_recov" and "hospitalised_death" to calculate total hospital demand.
+
 # daedalus.compare 0.0.5
 
 This patch version allows users to run multiple vaccination scenarios by passing a list of `<daedalus_vaccination>` objects to `run_scenarios()`.

--- a/R/scenario_helpers.R
+++ b/R/scenario_helpers.R
@@ -86,7 +86,11 @@ get_epidata_list <- function(l, names) {
     data.table::setDT(z)
 
     # NOTE: pass option of summarising by age group
-    z <- z[compartment == "hospitalised", list(value = sum(value)), by = "time"]
+    z <- z[
+      data.table::like(compartment, "hospitalised"),
+      list(value = sum(value)),
+      by = "time"
+    ]
     z$measure <- "total_hosp"
 
     z

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -12,6 +12,5 @@ SARS
 Sumali
 daedalus
 epi
-ji
-rpkg
+recov
 timeframe

--- a/tests/testthat/test-scenario-helpers.R
+++ b/tests/testthat/test-scenario-helpers.R
@@ -56,6 +56,17 @@ test_that("Fn `get_epicurve_data()` works", {
   expect_no_condition(
     get_epicurve_data(output, disease_tags, "wide")
   )
+
+  epicurve_data <- get_epicurve_data(output)
+  checkmate::expect_subset(
+    unique(epicurve_data[["measure"]]),
+    c(
+      "daily_deaths",
+      "daily_infections",
+      "daily_hospitalisations",
+      "total_hosp"
+    )
+  )
 })
 
 test_that("Fn `get_summary_data()` works", {


### PR DESCRIPTION
This patch version updates _daedalus.compare_ to be compatible with _daedalus_ >= v0.2.38 which introduced separate hospitalisation compartments in [daedalus PR 109](https://github.com/jameel-institute/daedalus/pull/109). This should have been fixed in v0.0.4 in PR #8.

- The function `get_epidata_list()` now accesses compartments "hospitalised_recov" and "hospitalised_death" to calculate total hospital demand.